### PR TITLE
13.9

### DIFF
--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -1,4 +1,6 @@
-const { response } = require('express');
+const {
+    response
+} = require('express');
 const request = require('supertest')
 const baseURL = 'http://localhost:3001/api/users'
 
@@ -6,7 +8,7 @@ beforeAll(async () => {
     const response = await request(baseURL).get('/');
     if (response.length = 0) {
         await request(baseURL).post('/').send({
-            username: 'tester',
+            username: 'tester@tester.com',
             name: 'Test Tester',
         });
     }
@@ -14,37 +16,44 @@ beforeAll(async () => {
 
 describe('GET /users', () => {
     it('should return 200', async () => {
-        const response = await request(baseURL).get('/');
+        const response = await request(baseURL).get('/')
         expect(response.statusCode).toBe(200);
-    });
-    it('should return a user with username tester', async () => {
-        const response = await request(baseURL).get('/');
+    })
+    it('should return a user  / users', async () => {
+        const response = await request(baseURL).get('/')
         expect(response.body.length >= 1).toBe(true);
-    });
-});
+    })
+})
 
 describe('POST /users', () => {
     it('should return 400 if user exits with the same username', async () => {
         const response = await request(baseURL).post('/').send({
-            username: 'tester',
+            username: 'tester@tester.com',
             name: 'Test Tester'
-        });
+        })
         expect(response.status).toBe(400)
-    });
+    })
     it('should return 400 if username or name is missing', async () => {
-        const response = await request(baseURL).post('/').send({});
+        const response = await request(baseURL).post('/').send({})
         expect(response.status).toBe(400)
-    });
-});
+    })
+    it('should return 400 if username is not an email', async () => {
+        const response = await request(baseURL).post('/').send({
+            username: 'teste',
+            name: 'Test Tester'
+        })
+        expect(response.status).toBe(400)
+    })
+})
 
 describe('PUT /users/:username', () => {
     it('should update name for given username', async () => {
-        const response = await request(baseURL).put(`/tester`).send({
+        const response = await request(baseURL).put(`/tester@tester.com`).send({
             name: 'Best Tester',
         });
         expect(response.statusCode).toBe(200)
         expect(response.body.name).toBe('Best Tester');
-        await request(baseURL).put(`/tester`).send({
+        await request(baseURL).put(`/tester@tester.com"`).send({
             name: 'Test Tester',
         });
     });

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -13,6 +13,7 @@ router.post('/', async (req, res) => {
     res.json(user)
   } catch(error) {
     if(error.message){
+      const message = error.message 
       return res.status(400).json({ message })
     }
     return res.status(400).json({ error })

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -12,6 +12,9 @@ router.post('/', async (req, res) => {
     const user = await User.create(req.body)
     res.json(user)
   } catch(error) {
+    if(error.message){
+      return res.status(400).json({ message })
+    }
     return res.status(400).json({ error })
   }
 })

--- a/models/user.js
+++ b/models/user.js
@@ -12,6 +12,9 @@ User.init({
   },
   username: {
     type: DataTypes.STRING,
+    validate: {
+      isEmail: true,
+    },
     unique:true,
     allowNull: false
   },


### PR DESCRIPTION
**Exercise 13.9.**
Sequelize provides a set of pre-defined [validations](https://sequelize.org/master/manual/validations-and-constraints.html) for the model fields, which it performs before storing the objects in the database.

It's decided to change the user creation policy so that only a valid email address is valid as a username. Implement validation that verifies this issue during the creation of a user.

Modify the error handling middleware to provide a more descriptive error message of the situation (for example, using the Sequelize error message), e.g.